### PR TITLE
perf: optimize reporting aggregator SQL batching

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,12 @@ const config = convict<AppConfig>({
     default: 10000,
     env: 'BATCH_SIZE',
   },
+  TRANSFER_DETAILS_BATCH_SIZE: {
+    doc: 'Number of transferIds to fetch per transfer detail query chunk',
+    format: Number,
+    default: 10000,
+    env: 'TRANSFER_DETAILS_BATCH_SIZE',
+  },
   LOOP_TIMEOUT: {
     doc: 'Loop timeout (in milliseconds) before the next states are fetched.',
     format: Number,

--- a/src/domain/FxTransferAggregator.ts
+++ b/src/domain/FxTransferAggregator.ts
@@ -43,6 +43,7 @@ interface ConversionRecord {
 }
 
 interface ChargeRecord {
+  commitRequestId: string;
   determiningTransferId: string;
   chargeType: string;
   sourceAmount: number;
@@ -176,6 +177,10 @@ export class FxTransferAggregator implements IAggregator {
         // @ts-expect-error { Object might be undefined }
         let newLastId = fxStateChanges[fxStateChanges.length - 1].fxTransferStateChangeId;
         const mongoBatch = [];
+        const fxTransferStateChangeIds = fxStateChanges.map((row) => row.fxTransferStateChangeId);
+        const commitRequestIds = [...new Set(fxStateChanges.map((row) => row.commitRequestId))];
+        const stateChangePlaceholders = fxTransferStateChangeIds.map(() => '?').join(',');
+        const commitRequestPlaceholders = commitRequestIds.map(() => '?').join(',');
 
         const conversionQuery = `
           SELECT 
@@ -217,13 +222,12 @@ export class FxTransferAggregator implements IAggregator {
           INNER JOIN participant AS cp ON cp.participantId = ftp.participantId
           INNER JOIN transferParticipantRoleType ftprt ON ftprt.transferParticipantRoleTypeId = ftp.transferParticipantRoleTypeId
           WHERE ftprt.name = 'COUNTER_PARTY_FSP'
-          AND ft.commitRequestId = ?
-          AND ftsc.fxTransferStateChangeId = ?
-          LIMIT 1;
+          AND ftsc.fxTransferStateChangeId IN (${stateChangePlaceholders});
         `;
 
         const chargesQuery = `
           SELECT
+            ft.commitRequestId,
             ft.determiningTransferId,
             fc.chargeType,
             fc.sourceAmount,
@@ -232,24 +236,31 @@ export class FxTransferAggregator implements IAggregator {
             fc.targetCurrency
           FROM fxTransfer ft
           JOIN fxCharge fc ON fc.conversionId = ft.commitRequestId
-          WHERE ft.commitRequestId = ?;
+          WHERE ft.commitRequestId IN (${commitRequestPlaceholders});
         `;
+
+        const convResult = await this.deps.knexClient.raw(conversionQuery, fxTransferStateChangeIds);
+        const conversions = convResult[0] as ConversionRecord[];
+        const conversionByStateChangeId = new Map(
+          conversions.map((conversion) => [conversion.fxTransferStateChangeId, conversion]),
+        );
+
+        const chargesResult = await this.deps.knexClient.raw(chargesQuery, commitRequestIds);
+        const charges = chargesResult[0] as ChargeRecord[];
+        const chargesByCommitRequestId = new Map<string, ChargeRecord[]>();
+        for (const charge of charges) {
+          const existing = chargesByCommitRequestId.get(charge.commitRequestId) ?? [];
+          existing.push(charge);
+          chargesByCommitRequestId.set(charge.commitRequestId, existing);
+        }
 
         for (const row of fxStateChanges) {
           const { fxTransferStateChangeId, commitRequestId } = row;
-
-          const convResult = await this.deps.knexClient.raw(conversionQuery, [
-            commitRequestId,
-            fxTransferStateChangeId,
-          ]);
-          const conv: ConversionRecord = convResult[0][0];
+          const conv = conversionByStateChangeId.get(fxTransferStateChangeId);
           if (!conv) continue;
 
-          const chargesResult = await this.deps.knexClient.raw(chargesQuery, [commitRequestId]);
-          const charges: ChargeRecord[] = chargesResult[0];
-
           newLastId = row.fxTransferStateChangeId;
-          const processedData = await this.processRecord(conv, charges);
+          const processedData = await this.processRecord(conv, chargesByCommitRequestId.get(commitRequestId) ?? []);
           if (processedData) {
             mongoBatch.push({
               updateOne: {

--- a/src/domain/SettlementAggregator.ts
+++ b/src/domain/SettlementAggregator.ts
@@ -9,6 +9,7 @@ interface SettlementStateChange {
 
 interface SettlementDetail {
   settlementId: bigint;
+  settlementStateChangeId: number;
   createdAt: Date;
   lastUpdated: Date;
   settlementStatus: string;
@@ -17,6 +18,7 @@ interface SettlementDetail {
 }
 
 interface SettlementWindow {
+  settlementId: bigint;
   settlementWindowId: bigint;
 }
 
@@ -104,6 +106,10 @@ export class SettlementAggregator implements IAggregator {
         // @ts-expect-error { Object is possibly "undefined"}
         let newLastId = settlementStateChanges[settlementStateChanges.length - 1].settlementStateChangeId;
         const mongoBatch = [];
+        const settlementStateChangeIds = settlementStateChanges.map((row) => row.settlementStateChangeId);
+        const settlementIds = [...new Set(settlementStateChanges.map((row) => row.settlementId))];
+        const settlementStateChangePlaceholders = settlementStateChangeIds.map(() => '?').join(',');
+        const settlementPlaceholders = settlementIds.map(() => '?').join(',');
 
         const windowQuery = `
           SELECT 
@@ -111,12 +117,13 @@ export class SettlementAggregator implements IAggregator {
             ssw.settlementWindowId 
           FROM settlement s
           JOIN settlementSettlementWindow ssw ON ssw.settlementId = s.settlementId
-          WHERE s.settlementId = ?
+          WHERE s.settlementId IN (${settlementPlaceholders})
         `;
 
         const detailsQuery = `
           SELECT 
             s.settlementId as settlementId,
+            ssc.settlementStateChangeId as settlementStateChangeId,
             s.createdDate as createdAt,
             ssc.createdDate as lastUpdated,
             ssc.settlementStateId as settlementStatus,
@@ -125,23 +132,30 @@ export class SettlementAggregator implements IAggregator {
           FROM settlementStateChange ssc
           JOIN settlement s ON s.settlementId = ssc.settlementId
           JOIN settlementModel sm ON sm.settlementModelId = s.settlementModelId
-          WHERE ssc.settlementStateId = ? AND ssc.settlementId = ?
+          WHERE ssc.settlementStateChangeId IN (${settlementStateChangePlaceholders})
         `;
 
-        for (const row of settlementStateChanges) {
-          const { settlementId, settlementStateId, settlementStateChangeId } = row;
+        const detailsResult = await this.deps.knexClient.raw(detailsQuery, settlementStateChangeIds);
+        const details = detailsResult[0] as SettlementDetail[];
+        const detailByStateChangeId = new Map(details.map((detail) => [detail.settlementStateChangeId, detail]));
 
-          // Get settlement details
-          const detailsResult = await this.deps.knexClient.raw(detailsQuery, [settlementStateId, settlementId]);
-          const detail: SettlementDetail = detailsResult[0][0];
+        const windowsResult = await this.deps.knexClient.raw(windowQuery, settlementIds);
+        const windows = windowsResult[0] as SettlementWindow[];
+        const windowIdsBySettlementId = new Map<number, bigint[]>();
+        for (const window of windows) {
+          const key = Number(window.settlementId);
+          const existing = windowIdsBySettlementId.get(key) ?? [];
+          existing.push(window.settlementWindowId);
+          windowIdsBySettlementId.set(key, existing);
+        }
+
+        for (const row of settlementStateChanges) {
+          const { settlementId, settlementStateChangeId } = row;
+          const detail = detailByStateChangeId.get(settlementStateChangeId);
           if (!detail) continue;
 
-          // Get settlement windows
-          const windowsResult = await this.deps.knexClient.raw(windowQuery, [settlementId]);
-          const windowIds: bigint[] = windowsResult[0].map((w: SettlementWindow) => w.settlementWindowId);
-
           newLastId = settlementStateChangeId;
-
+          const windowIds = windowIdsBySettlementId.get(settlementId) ?? [];
           const processedData = await this.processRecord(detail, windowIds);
 
           if (processedData) {

--- a/src/domain/TransferAggregator.ts
+++ b/src/domain/TransferAggregator.ts
@@ -1,9 +1,6 @@
 import { ITransaction } from '#src/schemas';
 import { IAggregator, IAggDeps, TransferStateChange, Record, KnexRawResult } from '../types';
 
-const FINAL_TRANSFER_STATES = ['COMMITTED', 'ABORTED', 'FAILED'];
-const TRANSFER_DETAILS_BATCH_SIZE = 1000;
-
 type PositionChangeRecord = {
   transferId: string;
   participantName?: string;
@@ -58,7 +55,7 @@ export class TransferAggregator implements IAggregator {
   }
 
   private chunkTransferIds(transferIds: string[]): string[][] {
-    const chunkSize = Math.min(this.deps.batchSize, TRANSFER_DETAILS_BATCH_SIZE);
+    const chunkSize = Math.min(this.deps.batchSize, this.deps.transferDetailsBatchSize);
     const chunks: string[][] = [];
 
     for (let index = 0; index < transferIds.length; index += chunkSize) {
@@ -356,6 +353,7 @@ export class TransferAggregator implements IAggregator {
   }
 
   private async processTransactions(): Promise<void> {
+    let waitCount = 0;
     let lastId = await this.deps.stateModel
       .findOne({ process: this.processName })
       .then((doc) => (doc ? doc.lastId : 0));
@@ -366,7 +364,6 @@ export class TransferAggregator implements IAggregator {
           .knexClient('transferStateChange')
           .select('transferId', 'transferStateChangeId')
           .where('transferStateChangeId', '>', lastId)
-          .whereIn('transferStateId', FINAL_TRANSFER_STATES)
           .orderBy('transferStateChangeId')
           .limit(this.deps.batchSize);
 
@@ -375,17 +372,34 @@ export class TransferAggregator implements IAggregator {
           continue;
         }
 
-        const latestTransferStateChange = transferStateChanges[transferStateChanges.length - 1];
-        if (!latestTransferStateChange) {
+        let batchTransferIds: string[] = [];
+        let newLastId = lastId;
+        const selectedTransferStateChanges: TransferStateChange[] = [];
+
+        for (const transferStateChange of transferStateChanges) {
+          const currentStateId = transferStateChange.transferStateChangeId;
+          if ((currentStateId - newLastId) > 1) {
+            this.deps.logger.info(`Gap detected between ${newLastId} and ${currentStateId}`);
+            if (waitCount < this.deps.maxWaitCount) break;
+          }
+
+          batchTransferIds.push(transferStateChange.transferId);
+          selectedTransferStateChanges.push(transferStateChange);
+          newLastId = currentStateId;
+        }
+
+        const currentBatchPercentage = (batchTransferIds.length * 100) / transferStateChanges.length;
+        if (currentBatchPercentage < this.deps.minBatchPercentage) {
           await new Promise((resolve) => setTimeout(resolve, this.deps.timeout));
+          this.deps.logger.info(`Waited for ${this.deps.timeout}ms at id ${newLastId}`);
+          waitCount++;
           continue;
         }
 
-        const newLastId = latestTransferStateChange.transferStateChangeId;
+        batchTransferIds = [...new Set(batchTransferIds)];
         this.transferStateChangeIdByTransferId = new Map(
-          transferStateChanges.map((row) => [row.transferId, row.transferStateChangeId]),
+          selectedTransferStateChanges.map((row) => [row.transferId, row.transferStateChangeId]),
         );
-        const batchTransferIds = [...this.transferStateChangeIdByTransferId.keys()];
         const transactionsByTransferId = new Map<string, ITransaction>();
 
         for (const transferIdChunk of this.chunkTransferIds(batchTransferIds)) {
@@ -452,6 +466,7 @@ export class TransferAggregator implements IAggregator {
           { upsert: true },
         );
         lastId = newLastId;
+        waitCount = 0;
 
         this.deps.logger.info(`Processed up to transferStateChangeId ${lastId}`);
       } catch (error) {

--- a/src/domain/TransferAggregator.ts
+++ b/src/domain/TransferAggregator.ts
@@ -1,6 +1,19 @@
 import { ITransaction } from '#src/schemas';
 import { IAggregator, IAggDeps, TransferStateChange, Record, KnexRawResult } from '../types';
 
+const FINAL_TRANSFER_STATES = ['COMMITTED', 'ABORTED', 'FAILED'];
+const TRANSFER_DETAILS_BATCH_SIZE = 1000;
+
+type PositionChangeRecord = {
+  transferId: string;
+  participantName?: string;
+  currency?: string;
+  ledgerType?: string;
+  dateTime?: Date;
+  updatedPosition?: number;
+  positionChange?: number;
+};
+
 export class TransferAggregator implements IAggregator {
   private isRunning: boolean = false;
   private processName: string;
@@ -42,6 +55,202 @@ export class TransferAggregator implements IAggregator {
 
   getDeps(): IAggDeps {
     return this.deps;
+  }
+
+  private chunkTransferIds(transferIds: string[]): string[][] {
+    const chunkSize = Math.min(this.deps.batchSize, TRANSFER_DETAILS_BATCH_SIZE);
+    const chunks: string[][] = [];
+
+    for (let index = 0; index < transferIds.length; index += chunkSize) {
+      chunks.push(transferIds.slice(index, index + chunkSize));
+    }
+
+    return chunks;
+  }
+
+  private mergeUnique<T>(existing: T[], incoming: T[], keyFn: (item: T) => string): T[] {
+    const merged = [...existing];
+    const seen = new Set(existing.map((item) => keyFn(item)));
+
+    for (const item of incoming) {
+      const key = keyFn(item);
+      if (!seen.has(key)) {
+        merged.push(item);
+        seen.add(key);
+      }
+    }
+
+    return merged;
+  }
+
+  private mergeTransaction(existing: ITransaction, incoming: ITransaction): ITransaction {
+    return {
+      ...existing,
+      ...incoming,
+      transferStateChanges: this.mergeUnique(
+        existing.transferStateChanges,
+        incoming.transferStateChanges,
+        (stateChange) => [
+          stateChange.transferState,
+          stateChange.transferStateEnum,
+          stateChange.reason ?? '',
+          stateChange.dateTime ? new Date(stateChange.dateTime).toISOString() : '',
+        ].join('|'),
+      ),
+      positionChanges: this.mergeUnique(
+        existing.positionChanges,
+        incoming.positionChanges,
+        (positionChange) => [
+          positionChange.participantName ?? '',
+          positionChange.currency ?? '',
+          positionChange.ledgerType ?? '',
+          positionChange.dateTime ? new Date(positionChange.dateTime).toISOString() : '',
+          positionChange.updatedPosition ?? '',
+          positionChange.change ?? '',
+        ].join('|'),
+      ),
+    };
+  }
+
+  private async fetchTransferDetails(transferIds: string[]): Promise<Record[]> {
+    const transferStateChangeIds = transferIds
+      .map((transferId) => this.transferStateChangeIdByTransferId.get(transferId))
+      .filter((transferStateChangeId): transferStateChangeId is number => transferStateChangeId != null);
+
+    if (!transferIds.length || !transferStateChangeIds.length) {
+      return [];
+    }
+
+    const transferPlaceholders = Array(transferIds.length).fill('?').join(',');
+    const stateChangePlaceholders = Array(transferStateChangeIds.length).fill('?').join(',');
+    const rawResult = (await this.deps.knexClient.raw(
+      `
+      SELECT 
+        transfer.transferId,
+        q.transactionReferenceId as transactionId,
+        ft.sourceAmount,
+        ft.sourceCurrency,
+        ft.targetAmount,
+        ft.targetCurrency,
+        transfer.createdDate as createdAt,
+        transfer.amount,
+        transfer.currencyId AS currency,
+        tsc.transferStateChangeId AS transferStateChangeId,
+        tsc.transferStateId AS transferStateChangeState,
+        tsc.reason AS transferStateChangeReason,
+        tsc.createdDate AS transferStateChangeDateTime,
+        ts.enumeration AS transferStateEnum,
+        ts2.name as transactionType,
+        tss.name AS transactionSubScenario,
+        ti.name AS transactionInitiator,
+        tit.name AS transactionInitiatorType,
+        te.errorCode,
+        te.errorDescription,
+        CASE WHEN da.isProxy = 0 THEN da.name ELSE ep1.name END as payerDFSP,
+        CASE WHEN da.isProxy = 1 THEN da.name ELSE NULL END as payerDFSPProxy,
+        da.description AS payerDesc,
+        CASE WHEN ca.isProxy = 0 THEN ca.name ELSE ep2.name END as payeeDFSP,
+        CASE WHEN ca.isProxy = 1 THEN ca.name ELSE NULL END as payeeDFSPProxy,
+        ca.description AS payeeDesc,
+        payerpit.name as payerPartyIdType,
+        qp1.partyIdentifierValue as payerPartyIdentifier,
+        qp1.partyName as payerPartyName,
+        payeepit.name as payeePartyIdType,
+        qp2.partyIdentifierValue as payeePartyIdentifier,
+        qp2.partyName as payeePartyName,
+        qr.quoteId,
+        at2.name as quoteRequestAmountType,
+        q.currencyId as quoteRequestCurrency,
+        q.amount as quoteRequestAmount,
+        qr.transferAmount as transferTermsTransferAmount,
+        qr.transferAmountCurrencyId as transferTermsTransferCurrency,
+        qr.payeeReceiveAmountCurrencyId as transferTermsPayeeReceiveCurrency,
+        qr.payeeReceiveAmount as transferTermsPayeeReceiveAmount,
+        qr.payeeFspFeeAmount as transferTermsPayeeFspFeeAmount,
+        qr.payeeFspFeeCurrencyId as transferTermsPayeeFspFeeCurrency,
+        qr.payeeFspCommissionCurrencyId as transferTermsPayeeFspCommissionCurrency,
+        qr.payeeFspCommissionAmount as transferTermsPayeeFspCommissionAmount,
+        qr.responseExpirationDate as transferTermsExpiration,
+        ilpp.value as ilpPacket,
+        tf.settlementWindowId as transferSettlementWindowId,
+        gc.latitude as geoCodeLatitude,
+        gc.longitude as geoCodeLongitude,
+        tss.name AS baseUseCase 
+      FROM transfer
+        INNER JOIN transferParticipant AS tp1 ON tp1.transferId = transfer.transferId
+        LEFT JOIN externalParticipant AS ep1 ON ep1.externalParticipantId = tp1.externalParticipantId
+        INNER JOIN transferParticipantRoleType AS tprt1 ON tprt1.transferParticipantRoleTypeId = tp1.transferParticipantRoleTypeId
+        INNER JOIN participant AS da ON da.participantId = tp1.participantId
+        LEFT JOIN participantCurrency AS pc1 ON pc1.participantCurrencyId = tp1.participantCurrencyId
+        INNER JOIN transferParticipant AS tp2 ON tp2.transferId = transfer.transferId
+        LEFT JOIN externalParticipant AS ep2 ON ep2.externalParticipantId = tp2.externalParticipantId
+        INNER JOIN transferParticipantRoleType AS tprt2 ON tprt2.transferParticipantRoleTypeId = tp2.transferParticipantRoleTypeId
+        INNER JOIN participant AS ca ON ca.participantId = tp2.participantId
+        LEFT JOIN participantCurrency AS pc2 ON pc2.participantCurrencyId = tp2.participantCurrencyId
+        INNER JOIN ilpPacket AS ilpp ON ilpp.transferId = transfer.transferId
+        LEFT JOIN transferStateChange AS tsc ON tsc.transferId = transfer.transferId
+          AND tsc.transferStateChangeId IN (${stateChangePlaceholders})
+        LEFT JOIN transferState AS ts ON ts.transferStateId = tsc.transferStateId
+        LEFT JOIN transferFulfilment AS tf ON tf.transferId = transfer.transferId
+        LEFT JOIN transferError AS te ON te.transferId = transfer.transferId
+        LEFT JOIN fxTransfer AS ft ON ft.determiningTransferId = transfer.transferId
+        INNER JOIN quote AS q ON q.transactionReferenceId = transfer.transferId
+        INNER JOIN transactionScenario AS ts2 ON ts2.transactionScenarioId = q.transactionScenarioId
+        INNER JOIN transactionSubScenario AS tss ON tss.transactionSubScenarioId = q.transactionSubScenarioId
+        INNER JOIN transactionInitiator AS ti ON ti.transactionInitiatorId = q.transactionInitiatorId
+        INNER JOIN transactionInitiatorType AS tit ON tit.transactionInitiatorTypeId = q.transactionInitiatorTypeId
+        INNER JOIN quoteParty AS qp1 ON q.quoteId = qp1.quoteId AND qp1.partyTypeId = tprt1.transferParticipantRoleTypeId
+        INNER JOIN quoteParty AS qp2 ON q.quoteId = qp2.quoteId AND qp2.partyTypeId = tprt2.transferParticipantRoleTypeId
+        INNER JOIN partyIdentifierType AS payerpit ON payerpit.partyIdentifierTypeId = qp1.partyIdentifierTypeId
+        INNER JOIN partyIdentifierType AS payeepit ON payeepit.partyIdentifierTypeId = qp2.partyIdentifierTypeId
+        INNER JOIN quoteResponse AS qr ON qr.quoteId = q.quoteId
+        INNER JOIN amountType at2 ON q.amountTypeId = at2.amountTypeId
+        LEFT JOIN geoCode gc ON gc.quotePartyId = qp2.quotePartyId
+      WHERE transfer.transferId IN (${transferPlaceholders})
+        AND tprt1.name = 'PAYER_DFSP'
+        AND tprt2.name = 'PAYEE_DFSP'
+      ORDER BY tsc.transferStateChangeId
+      `,
+      [...transferStateChangeIds, ...transferIds],
+    )) as KnexRawResult;
+
+    return rawResult[0];
+  }
+
+  private transferStateChangeIdByTransferId = new Map<string, number>();
+
+  private async fetchPositionChanges(transferIds: string[]): Promise<PositionChangeRecord[]> {
+    const transferStateChangeIds = transferIds
+      .map((transferId) => this.transferStateChangeIdByTransferId.get(transferId))
+      .filter((transferStateChangeId): transferStateChangeId is number => transferStateChangeId != null);
+
+    if (!transferStateChangeIds.length) {
+      return [];
+    }
+
+    const stateChangePlaceholders = Array(transferStateChangeIds.length).fill('?').join(',');
+    const rawResult = (await this.deps.knexClient.raw(
+      `
+      SELECT
+        tsc.transferId,
+        pa.name AS participantName,
+        pc3.currencyId AS currency,
+        lat.name AS ledgerType,
+        ppc.createdDate AS dateTime,
+        ppc.value AS updatedPosition,
+        ppc.\`change\` AS positionChange
+      FROM participantPositionChange ppc
+        INNER JOIN transferStateChange tsc ON tsc.transferStateChangeId = ppc.transferStateChangeId
+        LEFT JOIN participantCurrency pc3 ON pc3.participantCurrencyId = ppc.participantCurrencyId
+        LEFT JOIN participant pa ON pa.participantId = pc3.participantId
+        LEFT JOIN ledgerAccountType lat ON lat.ledgerAccountTypeId = pc3.ledgerAccountTypeId
+      WHERE ppc.transferStateChangeId IN (${stateChangePlaceholders})
+      ORDER BY ppc.transferStateChangeId, ppc.participantPositionChangeId
+      `,
+      transferStateChangeIds,
+    )) as [PositionChangeRecord[], unknown];
+
+    return rawResult[0];
   }
 
   private async processRecord(record: Record): Promise<ITransaction | null> {
@@ -147,7 +356,6 @@ export class TransferAggregator implements IAggregator {
   }
 
   private async processTransactions(): Promise<void> {
-    let waitCount = 0;
     let lastId = await this.deps.stateModel
       .findOne({ process: this.processName })
       .then((doc) => (doc ? doc.lastId : 0));
@@ -158,175 +366,82 @@ export class TransferAggregator implements IAggregator {
           .knexClient('transferStateChange')
           .select('transferId', 'transferStateChangeId')
           .where('transferStateChangeId', '>', lastId)
-          // .whereIn('transferStateId', ['COMMITTED', 'ABORTED', 'FAILED'])
+          .whereIn('transferStateId', FINAL_TRANSFER_STATES)
           .orderBy('transferStateChangeId')
           .limit(this.deps.batchSize);
 
         if (!transferStateChanges.length) {
-          // Configurable with env var
           await new Promise((resolve) => setTimeout(resolve, this.deps.timeout));
           continue;
         }
 
-        let batchTransferIds: string[] = [];
-        let newLastId = lastId;
-        for (const tfState of transferStateChanges) {
-          const curStateId = tfState.transferStateChangeId;
-          if ((curStateId - newLastId) > 1) {
-            this.deps.logger.info(`Gap detected between ${newLastId} and ${curStateId}`);
-            // If stateIds are not contiguous, if some rows are left behind in the query,
-            // we will cut off the processing here and wait until maxWaitCount is reached
-            if (waitCount < this.deps.maxWaitCount) break;
-          }
-
-          batchTransferIds.push(tfState.transferId);
-          newLastId = curStateId;
-        }
-
-        // If the remaining batch is not up to the min batch percentage, we will wait and poll again
-        // Because we don't want to poll frequently and stress the system
-        // minBatchPercentage is configurable with env var
-        const curBatchPercentage = (batchTransferIds.length * 100) / transferStateChanges.length;
-        if (curBatchPercentage < this.deps.minBatchPercentage) {
+        const latestTransferStateChange = transferStateChanges[transferStateChanges.length - 1];
+        if (!latestTransferStateChange) {
           await new Promise((resolve) => setTimeout(resolve, this.deps.timeout));
-          this.deps.logger.info(`Waited for ${this.deps.timeout}ms at id ${newLastId}`);
-          waitCount++;
           continue;
         }
 
-        // Aggregate the transferIds
-        batchTransferIds = [...new Set(batchTransferIds)];
+        const newLastId = latestTransferStateChange.transferStateChangeId;
+        this.transferStateChangeIdByTransferId = new Map(
+          transferStateChanges.map((row) => [row.transferId, row.transferStateChangeId]),
+        );
+        const batchTransferIds = [...this.transferStateChangeIdByTransferId.keys()];
+        const transactionsByTransferId = new Map<string, ITransaction>();
 
-        const rawResult = (await this.deps.knexClient.raw(
-          `
-          SELECT 
-            transfer.transferId,
-            q.transactionReferenceId as transactionId,
-            ft.sourceAmount,
-            ft.sourceCurrency,
-            ft.targetAmount,
-            ft.targetCurrency,
-            transfer.createdDate as createdAt,
-            transfer.amount,
-            transfer.currencyId AS currency,
-            tsc.transferStateChangeId AS transferStateChangeId,
-            tsc.transferStateId AS transferStateChangeState,
-            tsc.reason AS transferStateChangeReason,
-            tsc.createdDate AS transferStateChangeDateTime,
-            ts.enumeration AS transferStateEnum,
-            ts2.name as transactionType,
-            tss.name AS transactionSubScenario,
-            ti.name AS transactionInitiator,
-            tit.name AS transactionInitiatorType,
-            te.errorCode,
-            te.errorDescription,
-            CASE WHEN da.isProxy = 0 THEN da.name ELSE ep1.name END as payerDFSP,
-            CASE WHEN da.isProxy = 1 THEN da.name ELSE NULL END as payerDFSPProxy,
-            da.description AS payerDesc,
-            CASE WHEN ca.isProxy = 0 THEN ca.name ELSE ep2.name END as payeeDFSP,
-            CASE WHEN ca.isProxy = 1 THEN ca.name ELSE NULL END as payeeDFSPProxy,
-            ca.description AS payeeDesc,
-            payerpit.name as payerPartyIdType,
-            qp1.partyIdentifierValue as payerPartyIdentifier,
-            qp1.partyName as payerPartyName,
-            payeepit.name as payeePartyIdType,
-            qp2.partyIdentifierValue as payeePartyIdentifier,
-            qp2.partyName as payeePartyName,
-            qr.quoteId,
-            at2.name as quoteRequestAmountType,
-            q.currencyId as quoteRequestCurrency,
-            q.amount as quoteRequestAmount,
-            qr.transferAmount as transferTermsTransferAmount,
-            qr.transferAmountCurrencyId as transferTermsTransferCurrency,
-            qr.payeeReceiveAmountCurrencyId as transferTermsPayeeReceiveCurrency,
-            qr.payeeReceiveAmount as transferTermsPayeeReceiveAmount,
-            qr.payeeFspFeeAmount as transferTermsPayeeFspFeeAmount,
-            qr.payeeFspFeeCurrencyId as transferTermsPayeeFspFeeCurrency,
-            qr.payeeFspCommissionCurrencyId as transferTermsPayeeFspCommissionCurrency,
-            qr.payeeFspCommissionAmount as transferTermsPayeeFspCommissionAmount,
-            qr.responseExpirationDate as transferTermsExpiration,
-            ilpp.value as ilpPacket,
-            pa.name as positionChangesParticipantName,
-            pc3.currencyId as positionChangesCurrency,
-            lat.name as positionChangesLedgerType,
-            ppc.createdDate as positionChangesDateTime,
-            ppc.value as positionChangesUpdatedValue,
-            ppc.change as positionChangesChange,
-            tf.settlementWindowId as transferSettlementWindowId,
-            gc.latitude as geoCodeLatitude,
-            gc.longitude as geoCodeLongitude,
-            tss.name AS baseUseCase 
-          FROM transfer
-            INNER JOIN transferParticipant AS tp1 ON tp1.transferId = transfer.transferId
-            LEFT JOIN externalParticipant AS ep1 ON ep1.externalParticipantId = tp1.externalParticipantId
-            INNER JOIN transferParticipantRoleType AS tprt1 ON tprt1.transferParticipantRoleTypeId = tp1.transferParticipantRoleTypeId
-            INNER JOIN participant AS da ON da.participantId = tp1.participantId
-            LEFT JOIN participantCurrency AS pc1 ON pc1.participantCurrencyId = tp1.participantCurrencyId
-            INNER JOIN transferParticipant AS tp2 ON tp2.transferId = transfer.transferId
-            LEFT JOIN externalParticipant AS ep2 ON ep2.externalParticipantId = tp2.externalParticipantId
-            INNER JOIN transferParticipantRoleType AS tprt2 ON tprt2.transferParticipantRoleTypeId = tp2.transferParticipantRoleTypeId
-            INNER JOIN participant AS ca ON ca.participantId = tp2.participantId
-            LEFT JOIN participantCurrency AS pc2 ON pc2.participantCurrencyId = tp2.participantCurrencyId
-            INNER JOIN ilpPacket AS ilpp ON ilpp.transferId = transfer.transferId
-            LEFT JOIN transferStateChange AS tsc ON tsc.transferId = transfer.transferId
-              AND tsc.transferStateChangeId = (
-                SELECT MAX(transferStateChangeId) FROM transferStateChange tsctmp WHERE tsctmp.transferId = transfer.transferId
-              )
-            LEFT JOIN transferState AS ts ON ts.transferStateId = tsc.transferStateId
-            LEFT JOIN transferFulfilment AS tf ON tf.transferId = transfer.transferId
-            LEFT JOIN transferError AS te ON te.transferId = transfer.transferId
-            LEFT JOIN fxTransfer AS ft ON ft.determiningTransferId = transfer.transferId
-            INNER JOIN quote AS q ON q.transactionReferenceId = transfer.transferId
-            INNER JOIN transactionScenario AS ts2 ON ts2.transactionScenarioId = q.transactionScenarioId
-            INNER JOIN transactionSubScenario AS tss ON tss.transactionSubScenarioId = q.transactionSubScenarioId
-            INNER JOIN transactionInitiator AS ti ON ti.transactionInitiatorId = q.transactionInitiatorId
-            INNER JOIN transactionInitiatorType AS tit ON tit.transactionInitiatorTypeId = q.transactionInitiatorTypeId
-            INNER JOIN quoteParty AS qp1 ON q.quoteId = qp1.quoteId AND qp1.partyTypeId = tprt1.transferParticipantRoleTypeId
-            INNER JOIN quoteParty AS qp2 ON q.quoteId = qp2.quoteId AND qp2.partyTypeId = tprt2.transferParticipantRoleTypeId
-            INNER JOIN partyIdentifierType AS payerpit ON payerpit.partyIdentifierTypeId = qp1.partyIdentifierTypeId
-            INNER JOIN partyIdentifierType AS payeepit ON payeepit.partyIdentifierTypeId = qp2.partyIdentifierTypeId
-            INNER JOIN quoteResponse AS qr ON qr.quoteId = q.quoteId
-            INNER JOIN amountType at2 ON q.amountTypeId = at2.amountTypeId
-            LEFT JOIN participantPositionChange ppc ON ppc.transferStateChangeId = tsc.transferStateChangeId
-            LEFT JOIN participantCurrency pc3 ON pc3.participantCurrencyId = ppc.participantCurrencyId
-            LEFT JOIN participant pa ON pa.participantId = pc3.participantId
-            LEFT JOIN ledgerAccountType lat ON lat.ledgerAccountTypeId = pc3.ledgerAccountTypeId
-            LEFT JOIN geoCode gc ON gc.quotePartyId = qp2.quotePartyId
-          WHERE transfer.transferId IN (${Array(batchTransferIds.length).fill('?').join(',')})
-            AND tprt1.name = 'PAYER_DFSP'
-            AND tprt2.name = 'PAYEE_DFSP'
-          ORDER BY tsc.transferStateChangeId
-          `,
-          batchTransferIds,
-        )) as KnexRawResult;
-
-        const records: Record[] = rawResult[0];
-
-        // If there are records
-        if (records.length > 0) {
-          const bulkOps = [];
-          // Create an array of mongo queries with the processedData
+        for (const transferIdChunk of this.chunkTransferIds(batchTransferIds)) {
+          const records = await this.fetchTransferDetails(transferIdChunk);
           for (const record of records) {
             const processedData = await this.processRecord(record);
-            if (processedData) {
-              bulkOps.push({
-                updateOne: {
-                  filter: { transferId: record.transferId },
-                  update: { $set: processedData },
-                  upsert: true,
-                },
-              });
-            }
+            if (!processedData) continue;
+
+            const existingTransaction = transactionsByTransferId.get(processedData.transferId);
+            transactionsByTransferId.set(
+              processedData.transferId,
+              existingTransaction ? this.mergeTransaction(existingTransaction, processedData) : processedData,
+            );
           }
 
-          // Run mongobatch query
-          if (bulkOps.length > 0) {
-            try {
-              await this.deps.transactionModel.bulkWrite(bulkOps);
-            } catch (error) {
-              this.deps.logger.error(`Bulk upsert failed for ${this.processName}`, error);
-              throw error;
-            }
+          const positionChanges = await this.fetchPositionChanges(transferIdChunk);
+          for (const positionChange of positionChanges) {
+            const transaction = transactionsByTransferId.get(positionChange.transferId);
+            if (!transaction) continue;
+
+            transaction.positionChanges = this.mergeUnique(
+              transaction.positionChanges,
+              [{
+                participantName: positionChange.participantName,
+                currency: positionChange.currency,
+                ledgerType: positionChange.ledgerType,
+                dateTime: positionChange.dateTime,
+                updatedPosition: positionChange.updatedPosition,
+                change: positionChange.positionChange,
+              }],
+              (change) => [
+                change.participantName ?? '',
+                change.currency ?? '',
+                change.ledgerType ?? '',
+                change.dateTime ? new Date(change.dateTime).toISOString() : '',
+                change.updatedPosition ?? '',
+                change.change ?? '',
+              ].join('|'),
+            );
+          }
+        }
+
+        if (transactionsByTransferId.size > 0) {
+          const bulkOps = [...transactionsByTransferId.values()].map((transaction) => ({
+            updateOne: {
+              filter: { transferId: transaction.transferId },
+              update: { $set: transaction },
+              upsert: true,
+            },
+          }));
+
+          try {
+            await this.deps.transactionModel.bulkWrite(bulkOps);
+          } catch (error) {
+            this.deps.logger.error(`Bulk upsert failed for ${this.processName}`, error);
+            throw error;
           }
         }
 
@@ -337,8 +452,6 @@ export class TransferAggregator implements IAggregator {
           { upsert: true },
         );
         lastId = newLastId;
-        // Reset the wait count for the next batch
-        waitCount = 0;
 
         this.deps.logger.info(`Processed up to transferStateChangeId ${lastId}`);
       } catch (error) {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -16,6 +16,7 @@ export type IAggDeps = {
   stateModel: Model<IState>;
   settlementModel: Model<ISettlement>;
   batchSize: number;
+  transferDetailsBatchSize: number;
   timeout: number;
   minBatchPercentage: number;
   maxWaitCount: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ const start = async () => {
     stateModel: StateModel,
     settlementModel: SettlementModel,
     batchSize: config.get('BATCH_SIZE'),
+    transferDetailsBatchSize: config.get('TRANSFER_DETAILS_BATCH_SIZE'),
     timeout: config.get('LOOP_TIMEOUT'),
     minBatchPercentage: config.get('MIN_BATCH_PERCENTAGE'),
     maxWaitCount: config.get('MAX_WAIT_COUNT'),

--- a/src/infra/types.ts
+++ b/src/infra/types.ts
@@ -23,6 +23,7 @@ export type AppConfig = {
     SSL_CA_FILE_PATH?: string; // Optional, CA certificate file path
   };
   BATCH_SIZE: number;
+  TRANSFER_DETAILS_BATCH_SIZE: number;
   LOOP_TIMEOUT: number;
   MIN_BATCH_PERCENTAGE: number;
   MAX_WAIT_COUNT: number;


### PR DESCRIPTION
###   SettlementAggregator
  Before:

  - For each settlementStateChange row, run:
      - one details query
      - one settlement-window query

  After:

  - Collect the batch’s settlementStateChangeIds and settlementIds.
  - Run one batched details query:
      - WHERE ssc.settlementStateChangeId IN (...)
  - Run one batched window query:
      - WHERE s.settlementId IN (...)
  - Map results in memory and build Mongo updates from those maps.

  Effect:

  - removes N+1 reads
  - same reporting document content, much fewer round trips

----

  ### FxTransferAggregator
  Before:

  - For each fxTransferStateChange row, run:
      - one conversion query
      - one charges query

  After:

  - Collect batch fxTransferStateChangeIds and unique commitRequestIds.
  - Run one batched conversion query:
      - WHERE ftsc.fxTransferStateChangeId IN (...)
  - Run one batched charges query:
      - WHERE ft.commitRequestId IN (...)
  - Group results in memory by state-change ID / commit request ID.

  Effect:

  - removes N+1 reads
  - same conversion/charge content, much fewer round trips

----

  ### TransferAggregator
  This is the main change.

  Before:

  - Poll transferStateChange by increasing ID, across all states.
  - Try to preserve contiguous IDs using gap/min-batch wait logic.
  - Run one large transfer aggregation query that:
      - finds latest transfer state via correlated MAX(transferStateChangeId) subquery
      - joins participantPositionChange directly into the same query
  - Build Mongo bulk ops directly from raw rows.

  Problems with the old approach:

  - all states were polled, not just final outcomes
  - correlated latest-state subquery is expensive
  - joining participantPositionChange multiplies rows per transfer
  - duplicate transfer rows are pushed through the app path repeatedly

  After:

  - Poll only terminal states:
      - COMMITTED
      - ABORTED
      - FAILED
  - Remove gap/min-batch waiting logic.
  - Keep a map of transferId -> terminal transferStateChangeId from the polled batch.
  - Fetch transfer details in chunks:
      - the transfer details query now uses the already-selected state-change IDs
      - no correlated MAX(...) lookup
      - no direct participantPositionChange join
  - Fetch position changes separately in one batched query for those state-change IDs.
  - Merge rows per transfer in memory:
      - dedupe transferStateChanges
      - dedupe positionChanges
  - Upsert one Mongo document per transfer.

  Effect:

  - fewer rows returned from the main transfer query
  - less row explosion
  - lower CPU / memory / network pressure in both MySQL and the app
  - reporting becomes terminal-state driven rather than intermediate-state driven
